### PR TITLE
Change WM_DESTROY to WM_CLOSE. WM_DESTROY

### DIFF
--- a/src/pl_main_win32.c
+++ b/src/pl_main_win32.c
@@ -406,7 +406,7 @@ pl__windows_procedure(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
             break;
         }
 
-        case WM_DESTROY:
+        case WM_CLOSE:
         {
             PostQuitMessage(0);
             break;


### PR DESCRIPTION
WM_DESTROY will be called when the window will be destroyed.
WM_CLOSE will be called when the window will be closed. 

If there are intentions to build something beforehand, WM_CLOSE is needed